### PR TITLE
Gunicorn requirements bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
-    dist: xenial
-    sudo: true
 
+dist: xenial
 sudo: required
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
+    dist: xenial
+    sudo: true
 
 sudo: required
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
+
 sudo: required
 install:
-  - pip install tox
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=py35
+  - pip install tox-travis
 script:
   - tox
 
@@ -14,7 +17,6 @@ cache:
     - thrift-0.9.3
 
 before_install:
-  - pyenv global system 3.5
   - ls "thrift-0.9.3" | grep "bootstrap.sh" || wget https://github.com/apache/thrift/archive/0.9.3.tar.gz -O thrift.tar.gz
   - ls "thrift-0.9.3" | grep "bootstrap.sh" || tar xf thrift.tar.gz
   - cd thrift-0.9.3

--- a/requirements_py3x.txt
+++ b/requirements_py3x.txt
@@ -1,4 +1,4 @@
 setproctitle==1.1.10
-gevent>=1.2,<1.3
+gevent>=1.2
 gunicorn>=19.4.0
 thriftpy2>=0.4.0

--- a/test_requirements_py3x.txt
+++ b/test_requirements_py3x.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
-gevent==1.2.2
+gevent==1.4.0
 thrift>=0.9.3


### PR DESCRIPTION
Allow gevent > 1.3.0 (specifically, in my case, 1.4.0). Passes tox in 3.6, so hopefully the other environments pass after I submit this PR. Let me know if there are any concerns about the version bump, although honestly I was the one who put a limit in in the first place (probably out of misplaced caution) so I doubt there are specific fears.